### PR TITLE
fix(ci): disable body-max-line-length commitlint rule

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -22,6 +22,7 @@
     "subject-empty": [2, "never"],
     "subject-full-stop": [2, "never", "."],
     "type-case": [2, "always", "lower-case"],
-    "type-empty": [2, "never"]
+    "type-empty": [2, "never"],
+    "body-max-line-length": [0]
   }
 }


### PR DESCRIPTION
## Summary

- Dependabot commit bodies include long lines (URLs, markdown tables) that exceed the default 100-char `body-max-line-length` limit
- All Dependabot PRs fail the `Validate PR` / commitlint check with: `body's lines must not be longer than 100 characters [body-max-line-length]`
- This fix adds `"body-max-line-length": [0]` to `.commitlintrc.json` to disable the rule

## Test plan

- [ ] CI passes on this PR (commit body is short, so it would have passed before too)
- [ ] After merging, rebase Dependabot PRs (#10, #11) — they should pass commitlint

🤖 Generated with [Claude Code](https://claude.com/claude-code)