### PR TITLE
fix(ci): drop stale docker dependabot entry and resolve vite8/@codecov peer conflict

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,22 +41,3 @@ updates:
       npm-dependencies:
         patterns:
           - "*"
-
-  - package-ecosystem: "docker"
-    directory: "/tests/e2e"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "06:00"
-      timezone: "America/Chicago"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-    commit-message:
-      prefix: "chore(deps)"
-    cooldown:
-      default-days: 2
-    groups:
-      docker-dependencies:
-        patterns:
-          - "*"

--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -28,12 +28,17 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        # @codecov/vite-plugin@2.0.1 (latest published) only declares peer
+        # support for vite 4.x-6.x, but this repo runs vite 8. No published
+        # @codecov/vite-plugin version supports vite 8 yet, and downgrading
+        # vite would regress the app, so we tolerate the peer mismatch here
+        # rather than block dependency automation on an upstream lag.
+        run: npm ci --legacy-peer-deps
 
       - name: Update dependencies
         run: |
-          npm update
-          npm audit fix --force || true
+          npm update --legacy-peer-deps
+          npm audit fix --force --legacy-peer-deps || true
 
       - name: Run tests
         run: |


### PR DESCRIPTION
- Remove the docker package-ecosystem entry in dependabot.yml pointing at
  /tests/e2e; that Dockerfile no longer exists anywhere in the repo, so the
  native Dependabot docker job fails every run with "No Dockerfiles nor
  Kubernetes YAML found".
- Add --legacy-peer-deps to the Dependency Updates workflow's npm ci/update/
  audit fix steps. @codecov/vite-plugin@2.0.1 (latest published) only
  declares peer support for vite 4.x-6.x, but this repo runs vite 8; no
  newer @codecov/vite-plugin release exists yet, and downgrading vite would
  regress the app, so we tolerate the peer mismatch instead. This matches
  the --legacy-peer-deps pattern already used in ci-cd.yml and
  pull-request.yml.

Co-Authored-By: Claude <noreply@anthropic.com>
